### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@ Let Claude be your Redmine assistant! MCP Redmine connects Claude Desktop to you
 
 Uses httpx for API requests and integrates with the Redmine OpenAPI specification for comprehensive API coverage.
 
+<a href="https://glama.ai/mcp/servers/y08jjdmkyr">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/y08jjdmkyr/badge" alt="Redmine MCP server" />
+</a>
+
 ![MCP Redmine in action](screenshot.png)
 
 ## Requirements


### PR DESCRIPTION
This PR adds a badge for the [MCP Redmine](https://glama.ai/mcp/servers/y08jjdmkyr) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/y08jjdmkyr">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/y08jjdmkyr/badge" alt="Redmine MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.