### PR TITLE
Dockerize project and improve container usage documentation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10-slim
+FROM python:3.13-slim
 
 WORKDIR /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM python:3.10-slim
+
+WORKDIR /app
+
+COPY . /app
+
+RUN pip install --upgrade pip \
+    && pip install uv \
+    && uv sync
+
+CMD ["uv", "run", "--directory", "/app", "-m", "mcp_redmine.server", "main"]

--- a/README.md
+++ b/README.md
@@ -17,9 +17,11 @@ Uses httpx for API requests and integrates with the Redmine OpenAPI specificatio
 
 ![MCP Redmine in action](https://raw.githubusercontent.com/runekaagaard/mcp-redmine/refs/heads/main/screenshot.png)
 
-## Installation
 
-Ensure you have uv installed. 
+## Usage with Claude Desktop
+### 1. Installation using `uv`
+
+Ensure you have uv installed.
 ```bash
 uv --version
 ```
@@ -41,32 +43,74 @@ Install uv if you haven't already.
   powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 | iex"
   ```
 
-## Usage with Claude Desktop
-
 Add to your `claude_desktop_config.json`:
-
 ```json
-{
-  "mcpServers": {
-    "redmine": {
-      "command": "uvx",
-      "args": ["--from", "mcp-redmine==2025.04.09.153531", 
-               "--refresh-package", "mcp-redmine", "mcp-redmine"],
-      "env": {
-        "REDMINE_URL": "https://your-redmine-instance.example.com",
-        "REDMINE_API_KEY": "your-api-key",
-        "REDMINE_REQUEST_INSTRUCTIONS": "/path/to/instructions.md"
+  {
+    "mcpServers": {
+      "redmine": {
+        "command": "uvx",
+        "args": ["--from", "mcp-redmine==2025.04.09.153531", 
+                "--refresh-package", "mcp-redmine", "mcp-redmine"],
+        "env": {
+          "REDMINE_URL": "https://your-redmine-instance.example.com",
+          "REDMINE_API_KEY": "your-api-key",
+          "REDMINE_REQUEST_INSTRUCTIONS": "/path/to/instructions.md"
+        }
       }
     }
   }
-}
 ```
+
+### 2. Installation using `docker`
+
+Ensure you have docker installed. 
+```bash
+docker --version
+```
+
+Build docker image:
+```bash
+git clone git@github.com:runekaagaard/mcp-redmine.git
+cd mcp-redmine
+docker build -t mcp-redmine .
+```
+Add to your `claude_desktop_config.json`:
+  ```json
+  {
+    "mcpServers": {
+      "redmine": {
+        "command": "docker",
+        "args":  [
+            "run",
+            "-i",
+            "--rm",
+            "-e", "REDMINE_URL",
+            "-e", "REDMINE_API_KEY",
+            "-e", "REDMINE_REQUEST_INSTRUCTIONS",
+            "-v", "/path/to/instructions.md:/app/INSTRUCTIONS.md",
+            "mcp-redmine"
+        ],
+        "env": {
+          "REDMINE_URL": "https://your-redmine-instance.example.com",
+          "REDMINE_API_KEY": "your-api-key",
+          "REDMINE_REQUEST_INSTRUCTIONS": "/app/INSTRUCTIONS.md"
+        }
+      }
+    }
+  }
+  ```
 
 ## Environment Variables
 
 - `REDMINE_URL`: URL of your Redmine instance (required)
 - `REDMINE_API_KEY`: Your Redmine API key (required, see below for how to get it)
 - `REDMINE_REQUEST_INSTRUCTIONS`: Path to a file containing additional instructions for the redmine_request tool (optional). I've found it works great to have the LLM generate that file after a session. ([example1](INSTRUCTIONS_EXAMPLE1.md) [example2](INSTRUCTIONS_EXAMPLE2.md))
+
+> **Note**: When running via Docker, the `REDMINE_REQUEST_INSTRUCTIONS` environment variable must point to a **path inside the container**, not a path on the host machine.  
+> Therefore, if you want to use a local file, you need to **mount it into the container** at the correct location.
+>
+> If `REDMINE_REQUEST_INSTRUCTIONS` is not set, the server will try to load the file from the default path: `/app/INSTRUCTIONS.md` inside the container.
+
 
 ## Getting Your Redmine API Key
 

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+docker build -t mcp-redmine .

--- a/mcp_redmine/server.py
+++ b/mcp_redmine/server.py
@@ -9,19 +9,23 @@ from mcp.server.fastmcp.utilities.logging import get_logger
 
 VERSION = "2025.04.09.153531"
 
+# Load OpenAPI spec
+current_dir = pathlib.Path(__file__).parent
+with open(current_dir / 'redmine_openapi.yml') as f:
+    SPEC = yaml.safe_load(f)
+
 # Constants from environment
 REDMINE_URL = os.environ['REDMINE_URL']
 REDMINE_API_KEY = os.environ['REDMINE_API_KEY']
 if "REDMINE_REQUEST_INSTRUCTIONS" in os.environ:
     with open(os.environ["REDMINE_REQUEST_INSTRUCTIONS"]) as f:
         REDMINE_REQUEST_INSTRUCTIONS = f.read()
+elif os.path.exists(current_dir.parent / "INSTRUCTIONS.md"):
+    with open(current_dir.parent / "INSTRUCTIONS.md") as f:
+        REDMINE_REQUEST_INSTRUCTIONS = f.read()
 else:
     REDMINE_REQUEST_INSTRUCTIONS = ""
 
-# Load OpenAPI spec
-current_dir = pathlib.Path(__file__).parent
-with open(current_dir / 'redmine_openapi.yml') as f:
-    SPEC = yaml.safe_load(f)
 
 # Core
 def request(path: str, method: str = 'get', data: dict = None, params: dict = None,


### PR DESCRIPTION
## Changes:
- Add `Dockerfile` for containerization
- Update `README.md` with detailed Docker installation instructions
- Clarify `REDMINE_REQUEST_INSTRUCTIONS` handling for both host and container use

### I’d like to suggest a improvement for the project:
- Publish Docker Images to Docker Hub (ex: `runekaagaard/mcp-redmine:latest`)
Currently, Docker users need to clone the repository and build the image locally.
If you publish pre-built images to Docker Hub (or another public registry), users can simply pull the image directly, which will significantly improve the onboarding experience and lower the entry barrier for Docker users.
