### PR TITLE
fix: prevent redmine_download from overwriting files which already exist

### DIFF
--- a/mcp_redmine/server.py
+++ b/mcp_redmine/server.py
@@ -156,6 +156,7 @@ def redmine_download(attachment_id: int, save_path: str, filename: str = None) -
         path = pathlib.Path(save_path).expanduser()
         assert path.is_absolute(), f"Path must be fully qualified, got: {save_path}"
         assert not path.is_dir(), f"Path can't be a directory, got: {save_path}"
+        assert not path.exists(), f"File already exists: {save_path}"
 
         if not filename:
             attachment_response = request(f"attachments/{attachment_id}.json", "get")


### PR DESCRIPTION
This prevents the `redmine_download` tool from overwriting a file which already exists on the system. 

I'm thinking it'd be good to allow setting  a sandbox directory that limits where `redmine_upload` and `redmine_download` are allowed to read / save files on the filesystem (preventing it from reading secrets in `.env` for example). But, wanted to get your thoughts on that before proceeding, @runekaagaard.