### PR TITLE
add SSL verification bypass configuration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ Add to your `claude_desktop_config.json`:
 
 - `REDMINE_URL`: URL of your Redmine instance (required)
 - `REDMINE_API_KEY`: Your Redmine API key (required, see below for how to get it)
+- `REDMINE_SSL_VERIFY`: Whether to verify SSL certificates (optional, default: `true`). Set to `false` to bypass SSL certificate verification for self-signed certificates.
 - `REDMINE_REQUEST_INSTRUCTIONS`: Path to a file containing additional instructions for the redmine_request tool (optional). I've found it works great to have the LLM generate that file after a session. ([example1](INSTRUCTIONS_EXAMPLE1.md) [example2](INSTRUCTIONS_EXAMPLE2.md))
 
 > **Note**: When running via Docker, the `REDMINE_REQUEST_INSTRUCTIONS` environment variable must point to a **path inside the container**, not a path on the host machine.  

--- a/mcp_redmine/server.py
+++ b/mcp_redmine/server.py
@@ -17,6 +17,7 @@ with open(current_dir / 'redmine_openapi.yml') as f:
 # Constants from environment
 REDMINE_URL = os.environ['REDMINE_URL']
 REDMINE_API_KEY = os.environ['REDMINE_API_KEY']
+REDMINE_SSL_VERIFY = os.environ.get('REDMINE_SSL_VERIFY', 'true').lower() in ('true', '1', 'yes', 'on')
 if "REDMINE_REQUEST_INSTRUCTIONS" in os.environ:
     with open(os.environ["REDMINE_REQUEST_INSTRUCTIONS"]) as f:
         REDMINE_REQUEST_INSTRUCTIONS = f.read()
@@ -32,7 +33,7 @@ def request(path: str, method: str = 'get', data: dict = None, params: dict = No
 
     try:
         response = httpx.request(method=method.lower(), url=url, json=data, params=params, headers=headers,
-                                 content=content, timeout=60.0)
+                                 content=content, timeout=60.0, verify=REDMINE_SSL_VERIFY)
         response.raise_for_status()
 
         body = None


### PR DESCRIPTION
in some cases, ssl verification might need to be disabled. For example, when Redmine is hosted internally in a corporate. Therefore, to avoid messing with certificates locally (also because the IT support team is mostly useless), it's easier to just disable SSL verification from httpx. 
I added `REDMINE_SSL_VERIFY` as an _optional_ environment variable, so there is zero impact on your code :) and I also updated your readme to point out that there is also that mode as well.
Would be awesome if you merge this! 💯 
have a nice day