### PR TITLE
fix: Address issues #8, #19, #20, #21, #24 + security enhancement

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Add to your `claude_desktop_config.json`:
     "mcpServers": {
       "redmine": {
         "command": "uvx",
-        "args": ["--from", "mcp-redmine==2025.09.03.141435",
+        "args": ["--from", "mcp-redmine==2026.01.13.145604",
                 "--refresh-package", "mcp-redmine", "mcp-redmine"],
         "env": {
           "REDMINE_URL": "https://your-redmine-instance.example.com",

--- a/README.md
+++ b/README.md
@@ -49,12 +49,13 @@ Add to your `claude_desktop_config.json`:
     "mcpServers": {
       "redmine": {
         "command": "uvx",
-        "args": ["--from", "mcp-redmine==2025.09.03.141435", 
+        "args": ["--from", "mcp-redmine==2025.09.03.141435",
                 "--refresh-package", "mcp-redmine", "mcp-redmine"],
         "env": {
           "REDMINE_URL": "https://your-redmine-instance.example.com",
           "REDMINE_API_KEY": "your-api-key",
-          "REDMINE_REQUEST_INSTRUCTIONS": "/path/to/instructions.md"
+          "REDMINE_REQUEST_INSTRUCTIONS": "/path/to/instructions.md",
+          "REDMINE_ALLOWED_DIRECTORIES": "/tmp,/home/user/uploads"
         }
       }
     }
@@ -87,13 +88,16 @@ Add to your `claude_desktop_config.json`:
             "-e", "REDMINE_URL",
             "-e", "REDMINE_API_KEY",
             "-e", "REDMINE_REQUEST_INSTRUCTIONS",
+            "-e", "REDMINE_ALLOWED_DIRECTORIES",
             "-v", "/path/to/instructions.md:/app/INSTRUCTIONS.md",
+            "-v", "/path/to/uploads:/app/uploads",
             "mcp-redmine"
         ],
         "env": {
           "REDMINE_URL": "https://your-redmine-instance.example.com",
           "REDMINE_API_KEY": "your-api-key",
-          "REDMINE_REQUEST_INSTRUCTIONS": "/app/INSTRUCTIONS.md"
+          "REDMINE_REQUEST_INSTRUCTIONS": "/app/INSTRUCTIONS.md",
+          "REDMINE_ALLOWED_DIRECTORIES": "/app/uploads"
         }
       }
     }
@@ -102,12 +106,19 @@ Add to your `claude_desktop_config.json`:
 
 ## Environment Variables
 
-- `REDMINE_URL`: URL of your Redmine instance (required)
-- `REDMINE_API_KEY`: Your Redmine API key (required, see below for how to get it)
-- `REDMINE_REQUEST_INSTRUCTIONS`: Path to a file containing additional instructions for the redmine_request tool (optional). I've found it works great to have the LLM generate that file after a session. ([example1](INSTRUCTIONS_EXAMPLE1.md) [example2](INSTRUCTIONS_EXAMPLE2.md))
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `REDMINE_URL` | Yes | - | URL of your Redmine instance. Subpaths are supported (e.g., `http://localhost/redmine/`) |
+| `REDMINE_API_KEY` | Yes | - | Your Redmine API key (see below for how to get it) |
+| `REDMINE_REQUEST_INSTRUCTIONS` | No | - | Path to a file containing additional instructions for the redmine_request tool. I've found it works great to have the LLM generate that file after a session. ([example1](INSTRUCTIONS_EXAMPLE1.md) [example2](INSTRUCTIONS_EXAMPLE2.md)) |
+| `REDMINE_HEADERS` | No | (empty) | Custom HTTP headers to include in all requests. Format: `"Header1: Value1, Header2: Value2"`. Useful for proxies that require additional authentication (e.g., `X-Redmine-Username`) |
+| `REDMINE_RESPONSE_FORMAT` | No | `yaml` | Response format: `yaml` or `json`. Controls how API responses are formatted |
+| `REDMINE_ALLOWED_DIRECTORIES` | For upload/download | (disabled) | **Required for file operations.** Comma-separated list of directories where upload/download are allowed (e.g., `/tmp,/home/user/uploads`). Upload/download are disabled if not set for security |
 
-> **Note**: When running via Docker, the `REDMINE_REQUEST_INSTRUCTIONS` environment variable must point to a **path inside the container**, not a path on the host machine.  
+> **Note**: When running via Docker, the `REDMINE_REQUEST_INSTRUCTIONS` environment variable must point to a **path inside the container**, not a path on the host machine.
 > Therefore, if you want to use a local file, you need to **mount it into the container** at the correct location.
+
+> **Security Note**: The `REDMINE_ALLOWED_DIRECTORIES` setting protects against path traversal attacks. Paths containing `../` are resolved before validation, ensuring files can only be accessed within the allowed directories.
 
 
 ## Getting Your Redmine API Key
@@ -166,8 +177,9 @@ Add to your `claude_desktop_config.json`:
 
 - **redmine_upload**
   - Upload a file to Redmine and get a token for attachment
+  - **Requires `REDMINE_ALLOWED_DIRECTORIES` to be set**
   - Inputs:
-    - `file_path` (string): Fully qualified path to the file to upload
+    - `file_path` (string): Fully qualified path to the file to upload (must be within allowed directories)
     - `description` (string, optional): Optional description for the file
   - Returns YAML string with the same format as redmine_request, including upload token:
   ```yaml
@@ -181,9 +193,10 @@ Add to your `claude_desktop_config.json`:
 
 - **redmine_download**
   - Download an attachment from Redmine and save it to a local file
+  - **Requires `REDMINE_ALLOWED_DIRECTORIES` to be set**
   - Inputs:
     - `attachment_id` (integer): The ID of the attachment to download
-    - `save_path` (string): Fully qualified path where the file should be saved
+    - `save_path` (string): Fully qualified path where the file should be saved (must be within allowed directories)
     - `filename` (string, optional): Optional filename to use (determined automatically if not provided)
   - Returns YAML string with download results:
   ```yaml

--- a/mcp_redmine/server.py
+++ b/mcp_redmine/server.py
@@ -1,4 +1,4 @@
-import os, yaml, pathlib
+import os, yaml, pathlib, json, uuid
 from urllib.parse import urljoin
 
 import httpx
@@ -15,8 +15,25 @@ with open(current_dir / 'redmine_openapi.yml') as f:
     SPEC = yaml.safe_load(f)
 
 # Constants from environment
-REDMINE_URL = os.environ['REDMINE_URL']
+REDMINE_URL = os.environ['REDMINE_URL'].rstrip('/') + '/'  # Normalize to always end with /
 REDMINE_API_KEY = os.environ['REDMINE_API_KEY']
+REDMINE_RESPONSE_FORMAT = os.environ.get('REDMINE_RESPONSE_FORMAT', 'yaml').lower()
+
+# Custom headers (format: "Header1: Value1, Header2: Value2")
+REDMINE_HEADERS = {}
+if custom_headers := os.environ.get('REDMINE_HEADERS', ''):
+    for header in custom_headers.split(','):
+        if ':' in header:
+            key, value = header.split(':', 1)
+            REDMINE_HEADERS[key.strip()] = value.strip()
+
+# Allowed directories for upload/download (secure by default - disabled if not set)
+REDMINE_ALLOWED_DIRECTORIES = [
+    pathlib.Path(d.strip()).resolve()
+    for d in os.environ.get('REDMINE_ALLOWED_DIRECTORIES', '').split(',')
+    if d.strip()
+]
+
 if "REDMINE_REQUEST_INSTRUCTIONS" in os.environ:
     with open(os.environ["REDMINE_REQUEST_INSTRUCTIONS"]) as f:
         REDMINE_REQUEST_INSTRUCTIONS = f.read()
@@ -27,7 +44,11 @@ else:
 # Core
 def request(path: str, method: str = 'get', data: dict = None, params: dict = None,
             content_type: str = 'application/json', content: bytes = None) -> dict:
-    headers = {'X-Redmine-API-Key': REDMINE_API_KEY, 'Content-Type': content_type}
+    headers = {
+        'X-Redmine-API-Key': REDMINE_API_KEY,
+        'Content-Type': content_type,
+        **REDMINE_HEADERS
+    }
     url = urljoin(REDMINE_URL, path.lstrip('/'))
 
     try:
@@ -59,9 +80,45 @@ def request(path: str, method: str = 'get', data: dict = None, params: dict = No
 
         return {"status_code": status_code, "body": body, "error": f"{e.__class__.__name__}: {e}"}
         
-def yd(obj):
-    # Allow direct Unicode output, prevent line wrapping for long lines, and avoid automatic key sorting.
+def format_response(obj):
+    """Format response as YAML or JSON based on REDMINE_RESPONSE_FORMAT env var."""
+    if REDMINE_RESPONSE_FORMAT == 'json':
+        return json.dumps(obj, ensure_ascii=False, indent=2, default=str)
+    # YAML: Allow direct Unicode output, prevent line wrapping for long lines, and avoid automatic key sorting.
     return yaml.safe_dump(obj, allow_unicode=True, sort_keys=False, width=4096)
+
+
+def wrap_insecure_content(content: str) -> str:
+    """Wrap content that may contain user-generated data with security tags to prevent prompt injection."""
+    tag_id = uuid.uuid4().hex[:16]
+    return f"<insecure-content-{tag_id}>\n{content}\n</insecure-content-{tag_id}>"
+
+
+def validate_path(file_path: str, must_exist: bool = True) -> tuple[str | None, pathlib.Path | None]:
+    """
+    Validate and resolve a file path.
+    Returns (None, resolved_path) on success, (error_message, None) on failure.
+    """
+    # Require allowed directories to be configured (secure by default)
+    if not REDMINE_ALLOWED_DIRECTORIES:
+        return "File operations disabled: REDMINE_ALLOWED_DIRECTORIES not configured", None
+
+    try:
+        path = pathlib.Path(file_path).expanduser().resolve()
+    except Exception as e:
+        return f"Invalid path: {file_path} ({e})", None
+
+    if not path.is_absolute():
+        return f"Path must be absolute, got: {file_path}", None
+
+    # Check path is within allowed directories
+    if not any(path.is_relative_to(allowed) for allowed in REDMINE_ALLOWED_DIRECTORIES):
+        return f"Path not in allowed directories: {file_path}", None
+
+    if must_exist and not path.exists():
+        return f"File not found: {path}", None
+
+    return None, path
 
 
 # Tools
@@ -83,7 +140,7 @@ Returns:
 {}""".format(REDMINE_REQUEST_INSTRUCTIONS).strip())
     
 def redmine_request(path: str, method: str = 'get', data: dict = None, params: dict = None) -> str:
-    return yd(request(path, method=method, data=data, params=params))
+    return wrap_insecure_content(format_response(request(path, method=method, data=data, params=params)))
 
 @mcp.tool()
 def redmine_paths_list() -> str:
@@ -95,7 +152,7 @@ def redmine_paths_list() -> str:
     Returns:
         str: YAML string containing a list of path templates (e.g. '/issues.json')
     """
-    return yd(list(SPEC['paths'].keys()))
+    return format_response(list(SPEC['paths'].keys()))
 
 @mcp.tool()
 def redmine_paths_info(path_templates: list) -> str:
@@ -112,26 +169,26 @@ def redmine_paths_info(path_templates: list) -> str:
         if path in SPEC['paths']:
             info[path] = SPEC['paths'][path]
 
-    return yd(info)
+    return format_response(info)
 
 @mcp.tool()
 def redmine_upload(file_path: str, description: str = None) -> str:
     """
     Upload a file to Redmine and get a token for attachment
-    
+
     Args:
-        file_path: Fully qualified path to the file to upload
+        file_path: Fully qualified path to the file to upload (must be within REDMINE_ALLOWED_DIRECTORIES)
         description: Optional description for the file
-        
+
     Returns:
         str: YAML string containing response status code, body and error message
              The body contains the attachment token
     """
-    try:
-        path = pathlib.Path(file_path).expanduser()
-        assert path.is_absolute(), f"Path must be fully qualified, got: {file_path}"
-        assert path.exists(), f"File does not exist: {file_path}"
+    error, path = validate_path(file_path, must_exist=True)
+    if error:
+        return format_response({"status_code": 0, "body": None, "error": error})
 
+    try:
         params = {'filename': path.name}
         if description:
             params['description'] = description
@@ -141,47 +198,53 @@ def redmine_upload(file_path: str, description: str = None) -> str:
 
         result = request(path='uploads.json', method='post', params=params,
                          content_type='application/octet-stream', content=file_content)
-        return yd(result)
+        return format_response(result)
     except Exception as e:
-        return yd({"status_code": 0, "body": None, "error": f"{e.__class__.__name__}: {e}"})
+        return format_response({"status_code": 0, "body": None, "error": f"{e.__class__.__name__}: {e}"})
 
 @mcp.tool()
 def redmine_download(attachment_id: int, save_path: str, filename: str = None) -> str:
     """
     Download an attachment from Redmine and save it to a local file
-    
+
     Args:
         attachment_id: The ID of the attachment to download
-        save_path: Fully qualified path where the file should be saved to
-        filename: Optional filename to use for the attachment. If not provided, 
+        save_path: Fully qualified path where the file should be saved to (must be within REDMINE_ALLOWED_DIRECTORIES)
+        filename: Optional filename to use for the attachment. If not provided,
                  will be determined from attachment data or URL
-        
+
     Returns:
         str: YAML string containing download status, file path, and any error messages
     """
-    try:
-        path = pathlib.Path(save_path).expanduser()
-        assert path.is_absolute(), f"Path must be fully qualified, got: {save_path}"
-        assert not path.is_dir(), f"Path can't be a directory, got: {save_path}"
+    error, path = validate_path(save_path, must_exist=False)
+    if error:
+        return format_response({"status_code": 0, "body": None, "error": error})
 
+    if path.is_dir():
+        return format_response({"status_code": 0, "body": None, "error": f"Path can't be a directory: {save_path}"})
+
+    try:
         if not filename:
             attachment_response = request(f"attachments/{attachment_id}.json", "get")
             if attachment_response["status_code"] != 200:
-                return yd(attachment_response)
+                return format_response(attachment_response)
 
             filename = attachment_response["body"]["attachment"]["filename"]
 
         response = request(f"attachments/download/{attachment_id}/{filename}", "get",
                            content_type="application/octet-stream")
         if response["status_code"] != 200 or not response["body"]:
-            return yd(response)
+            return format_response(response)
+
+        # Create parent directories if needed
+        path.parent.mkdir(parents=True, exist_ok=True)
 
         with open(path, 'wb') as f:
             f.write(response["body"])
 
-        return yd({"status_code": 200, "body": {"saved_to": str(path), "filename": filename}, "error": ""})
+        return format_response({"status_code": 200, "body": {"saved_to": str(path), "filename": filename}, "error": ""})
     except Exception as e:
-        return yd({"status_code": 0, "body": None, "error": f"{e.__class__.__name__}: {e}"})
+        return format_response({"status_code": 0, "body": None, "error": f"{e.__class__.__name__}: {e}"})
 
 def main():
     """Main entry point for the mcp-redmine package."""

--- a/mcp_redmine/server.py
+++ b/mcp_redmine/server.py
@@ -7,7 +7,7 @@ from mcp.server.fastmcp.utilities.logging import get_logger
 
 ### Constants ###
 
-VERSION = "2025.09.03.141435"
+VERSION = "2026.01.13.145604"
 
 # Load OpenAPI spec
 current_dir = pathlib.Path(__file__).parent

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcp-redmine"
-version = "2025.09.03.141435"
+version = "2026.01.13.145604"
 description = "A MCP server that connects to your Redmine instance"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -568,7 +568,7 @@ cli = [
 
 [[package]]
 name = "mcp-redmine"
-version = "2025.9.3.141435"
+version = "2026.1.13.145604"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary

This PR addresses 5 open GitHub issues and adds a security enhancement:

### Bug Fixes
- **#19** - Base URL subpath not working: Normalize `REDMINE_URL` to always end with `/`
- **#21** - Download path issues: Create parent directories automatically, improve error messages
- **#24** - Upload path validation: Use `resolve()` for paths, better error handling

### Features
- **#8** - JSON output format: Add `REDMINE_RESPONSE_FORMAT` env var (`yaml`/`json`)
- **#20** - Custom headers: Add `REDMINE_HEADERS` env var for additional HTTP headers

### Security Enhancement
- Add `REDMINE_ALLOWED_DIRECTORIES` to restrict upload/download to whitelisted paths
- Upload/download **disabled by default** (secure by default)
- Path traversal attacks (`../`) blocked via `resolve()` + `is_relative_to()` check

## Breaking Change

⚠️ **Upload/download now require `REDMINE_ALLOWED_DIRECTORIES` to be set.**

Users who need file operations must add:
```bash
export REDMINE_ALLOWED_DIRECTORIES="/path/to/uploads,/another/path"
```

## New Environment Variables

| Variable | Default | Description |
|----------|---------|-------------|
| `REDMINE_HEADERS` | (empty) | Custom HTTP headers: `"Header1: Value1, Header2: Value2"` |
| `REDMINE_RESPONSE_FORMAT` | `yaml` | Response format: `yaml` or `json` |
| `REDMINE_ALLOWED_DIRECTORIES` | (disabled) | Required for file ops: `"/tmp,/home/user"` |

## Test Plan

- [x] Verify URL subpath works: `REDMINE_URL=http://localhost/redmine`
- [x] Test upload with allowed directory configured
- [x] Test download creates parent directories
- [x] Verify path traversal is blocked (`/tmp/../etc/passwd`)
- [x] Test JSON response format
- [x] Test custom headers are sent

Closes #8, #19, #20, #21, #24