### PR TITLE
fix: remove redundant 'main' argument from Docker and README

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,4 +8,4 @@ RUN pip install --upgrade pip \
     && pip install uv \
     && uv sync
 
-CMD ["uv", "run", "--directory", "/app", "-m", "mcp_redmine.server", "main"]
+CMD ["uv", "run", "--directory", "/app", "-m", "mcp_redmine.server"]

--- a/README.md
+++ b/README.md
@@ -261,7 +261,7 @@ Then set this in claude_desktop_config.json:
 ```
 ...
 "command": "uv",
-"args": ["run", "--directory", "/path/to/mcp-redmine", "-m", "mcp_redmine.server", "main"],
+"args": ["run", "--directory", "/path/to/mcp-redmine", "-m", "mcp_redmine.server"],
 ...
 ```
 


### PR DESCRIPTION
The main argument was causing an unrecognized arguments: main error during startup. This is because the main() function in server.py was recently updated to use argparse, which does not accept positional arguments by default.

 Changes:
 - Removed "main" from the CMD instruction in Dockerfile.
 - Updated the uv run example in README.md to remove the redundant "main" argument.