### PR TITLE
feat: Split `redmine_request` tool into method-specific tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Add to your `claude_desktop_config.json`:
 |----------|----------|---------|-------------|
 | `REDMINE_URL` | Yes | - | URL of your Redmine instance. Subpaths are supported (e.g., `http://localhost/redmine/`) |
 | `REDMINE_API_KEY` | Yes | - | Your Redmine API key (see below for how to get it) |
-| `REDMINE_REQUEST_INSTRUCTIONS` | No | - | Path to a file containing additional instructions for the redmine_request tool. I've found it works great to have the LLM generate that file after a session. ([example1](INSTRUCTIONS_EXAMPLE1.md) [example2](INSTRUCTIONS_EXAMPLE2.md)) |
+| `REDMINE_REQUEST_INSTRUCTIONS` | No | - | Path to a file containing additional instructions for the redmine_request_* tools. I've found it works great to have the LLM generate that file after a session. ([example1](INSTRUCTIONS_EXAMPLE1.md) [example2](INSTRUCTIONS_EXAMPLE2.md)) |
 | `REDMINE_HEADERS` | No | (empty) | Custom HTTP headers to include in all requests. Format: `"Header1: Value1, Header2: Value2"`. Useful for proxies that require additional authentication (e.g., `X-Redmine-Username`) |
 | `REDMINE_RESPONSE_FORMAT` | No | `yaml` | Response format: `yaml` or `json`. Controls how API responses are formatted |
 | `REDMINE_ALLOWED_DIRECTORIES` | For upload/download | (disabled) | **Required for file operations.** Comma-separated list of directories where upload/download are allowed (e.g., `/tmp,/home/user/uploads`). Upload/download are disabled if not set for security |
@@ -158,12 +158,11 @@ Add to your `claude_desktop_config.json`:
       ...
   ```
 
-- **redmine_request**
-  - Make a request to the Redmine API
-  - Inputs:
+- **redmine_request_get**, **redmine_request_post**, **redmine_request_put**, **redmine_request_patch**, **redmine_request_delete**
+  - Make a method-specific request to the Redmine API
+  - Inputs (vary by method):
     - `path` (string): API endpoint path (e.g. '/issues.json')
-    - `method` (string, optional): HTTP method to use (default: 'get')
-    - `data` (object, optional): Dictionary for request body (for POST/PUT)
+    - `data` (object, optional): Dictionary for request body (for POST/PUT/PATCH)
     - `params` (object, optional): Dictionary for query parameters
   - Returns YAML string containing response status code, body and error message:
   ```yaml

--- a/mcp_redmine/server.py
+++ b/mcp_redmine/server.py
@@ -129,21 +129,77 @@ mcp = FastMCP("Redmine MCP server")
 get_logger(__name__).info(f"Starting MCP Redmine version {VERSION}")
 
 @mcp.tool(description="""
-Make a request to the Redmine API
+Make a GET request to the Redmine API
 
 Args:
     path: API endpoint path (e.g. '/issues.json')
-    method: HTTP method to use (default: 'get')
-    data: Dictionary for request body (for POST/PUT)
     params: Dictionary for query parameters
 
 Returns:
     str: YAML string containing response status code, body and error message
 
 {}""".format(REDMINE_REQUEST_INSTRUCTIONS).strip())
-    
-def redmine_request(path: str, method: str = 'get', data: dict = None, params: dict = None) -> str:
-    return wrap_insecure_content(format_response(request(path, method=method, data=data, params=params)))
+def redmine_request_get(path: str, params: dict = None) -> str:
+    return wrap_insecure_content(format_response(request(path, method='get', params=params)))
+
+@mcp.tool(description="""
+Make a POST request to the Redmine API
+
+Args:
+    path: API endpoint path (e.g. '/issues.json')
+    data: Dictionary for request body
+    params: Dictionary for query parameters
+
+Returns:
+    str: YAML string containing response status code, body and error message
+
+{}""".format(REDMINE_REQUEST_INSTRUCTIONS).strip())
+def redmine_request_post(path: str, data: dict = None, params: dict = None) -> str:
+    return wrap_insecure_content(format_response(request(path, method='post', data=data, params=params)))
+
+@mcp.tool(description="""
+Make a PUT request to the Redmine API
+
+Args:
+    path: API endpoint path (e.g. '/issues.json')
+    data: Dictionary for request body
+    params: Dictionary for query parameters
+
+Returns:
+    str: YAML string containing response status code, body and error message
+
+{}""".format(REDMINE_REQUEST_INSTRUCTIONS).strip())
+def redmine_request_put(path: str, data: dict = None, params: dict = None) -> str:
+    return wrap_insecure_content(format_response(request(path, method='put', data=data, params=params)))
+
+@mcp.tool(description="""
+Make a PATCH request to the Redmine API
+
+Args:
+    path: API endpoint path (e.g. '/issues.json')
+    data: Dictionary for request body
+    params: Dictionary for query parameters
+
+Returns:
+    str: YAML string containing response status code, body and error message
+
+{}""".format(REDMINE_REQUEST_INSTRUCTIONS).strip())
+def redmine_request_patch(path: str, data: dict = None, params: dict = None) -> str:
+    return wrap_insecure_content(format_response(request(path, method='patch', data=data, params=params)))
+
+@mcp.tool(description="""
+Make a DELETE request to the Redmine API
+
+Args:
+    path: API endpoint path (e.g. '/issues.json')
+    params: Dictionary for query parameters
+
+Returns:
+    str: YAML string containing response status code, body and error message
+
+{}""".format(REDMINE_REQUEST_INSTRUCTIONS).strip())
+def redmine_request_delete(path: str, params: dict = None) -> str:
+    return wrap_insecure_content(format_response(request(path, method='delete', params=params)))
 
 @mcp.tool()
 def redmine_paths_list() -> str:


### PR DESCRIPTION
## Description
This PR splits the unified `redmine_request` tool into 5 method-specific tools:
- `redmine_request_get`
- `redmine_request_post`
- `redmine_request_put`
- `redmine_request_patch`
- `redmine_request_delete`

## Motivation
Previously, because a single `redmine_request` tool handled all HTTP methods, it was difficult for users to set granular, method-based authorization policies in their MCP clients.
(e.g., auto-approving `GET` requests for reading data, while requiring explicit confirmation for state-changing requests like `POST`, `PUT`, or `DELETE`)

By splitting the tool into individual endpoints, users can now securely and flexibly manage their permissions per HTTP method, reducing unnecessary interruptions during LLM tasks.

## Changes Made
- Replaced the single `redmine_request` function in `mcp_redmine/server.py` with 5 individual tools.
- Ensured `REDMINE_REQUEST_INSTRUCTIONS` is still properly injected into the descriptions of all 5 new tools.
- Updated the API Documentation section in `README.md` to reflect these changes.

## Testing
- Verified that all 5 individual tools are registered and successfully exposed to the MCP client.
- Tested `GET`, `POST`, `PUT`, `PATCH`, and `DELETE` requests locally against a live Redmine instance using the `/issues.json` endpoints and confirmed they all execute and modify state correctly.