### PR TITLE
feat: Add multi-user support via user_identifier parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,14 @@ Let Claude be your Redmine assistant! MCP Redmine connects Claude Desktop to you
 - Manage and track time entries
 - Update issue statuses and fields
 - Access comprehensive Redmine API functionality
+- **Multi-user support** via user identifier to API key mapping (for orchestrated environments like n8n + OpenWebUI)
 
 Uses httpx for API requests and integrates with the Redmine OpenAPI specification for comprehensive API coverage.
 
 ![MCP Redmine in action](https://raw.githubusercontent.com/runekaagaard/mcp-redmine/refs/heads/main/screenshot.png)
+
+> [!CAUTION]
+> **Multi-user mode is designed exclusively for use in closed, trusted networks (e.g. internal company infrastructure behind a VPN/firewall). It must NEVER be exposed to the public internet.** The user-to-API-key mapping file contains sensitive credentials. The `user_identifier` parameter is passed as a plain tool call argument and is not cryptographically verified — any client that can reach this MCP server can impersonate any user. Only deploy this in environments where all clients are trusted and network access is strictly controlled.
 
 
 ## Usage with Claude Desktop
@@ -64,7 +68,7 @@ Add to your `claude_desktop_config.json`:
 
 ### 2. Installation using `docker`
 
-Ensure you have docker installed. 
+Ensure you have docker installed.
 ```bash
 docker --version
 ```
@@ -104,12 +108,137 @@ Add to your `claude_desktop_config.json`:
   }
   ```
 
+## Multi-User Mode (n8n + OpenWebUI)
+
+Multi-user mode allows a single MCP server instance to serve multiple Redmine users, each authenticated with their own API key. This is designed for orchestrated environments where a middleware (like **n8n**) sits between the user-facing UI (like **OpenWebUI**) and this MCP server.
+
+> [!CAUTION]
+> **This mode is intended ONLY for closed, trusted networks.** See the security warning at the top of this document.
+
+### How It Works
+
+```
+User (OpenWebUI) ──→ n8n (knows user email) ──→ MCP tool call + user_identifier ──→ mcp-redmine ──→ Redmine API
+```
+
+1. The user chats in OpenWebUI, which passes the user's email to n8n.
+2. n8n calls MCP tools and includes the `user_identifier` parameter (the user's email) in **every** tool call.
+3. mcp-redmine looks up the user's Redmine API key from the configured users map file.
+4. The request is made to Redmine using that user's API key, so all actions respect that user's Redmine permissions.
+
+### Configuration
+
+#### 1. Create a users map file
+
+Create a JSON file mapping user identifiers (emails) to their Redmine API keys:
+
+```json
+{
+  "jan.kowalski@company.com": "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2",
+  "anna.nowak@company.com": "f6e5d4c3b2a1f6e5d4c3b2a1f6e5d4c3b2a1f6e5"
+}
+```
+
+Save it e.g. as `/config/redmine_users.json`.
+
+> **Hot-reload**: The users map file is re-read on every request. You can add or remove users without restarting the MCP server.
+
+#### 2. Configure environment variables
+
+Set `REDMINE_USERS_MAP` instead of (or in addition to) `REDMINE_API_KEY`:
+
+```bash
+# Required
+REDMINE_URL=https://redmine.company.com
+REDMINE_USERS_MAP=/config/redmine_users.json
+
+# Optional: fallback key used when no user_identifier is provided
+REDMINE_API_KEY=fallback-api-key
+```
+
+Alternatively, for simple setups, you can pass the map as inline JSON:
+
+```bash
+REDMINE_USERS_MAP='{"jan.kowalski@company.com": "key1", "anna.nowak@company.com": "key2"}'
+```
+
+#### 3. Docker deployment example (SSE transport)
+
+```bash
+docker run -d \
+  --name mcp-redmine \
+  -e REDMINE_URL=https://redmine.company.com \
+  -e REDMINE_USERS_MAP=/config/redmine_users.json \
+  -v /path/to/redmine_users.json:/config/redmine_users.json:ro \
+  -p 8000:8000 \
+  mcp-redmine \
+  --transport sse --host 0.0.0.0 --port 8000
+```
+
+### n8n Integration
+
+When calling MCP tools from n8n, **every tool call MUST include the `user_identifier` parameter**. This is how the server knows which user's API key to use.
+
+Example n8n tool call payload:
+
+```json
+{
+  "tool": "redmine_request",
+  "arguments": {
+    "path": "/issues.json",
+    "method": "get",
+    "params": {"project_id": "my-project"},
+    "user_identifier": "jan.kowalski@company.com"
+  }
+}
+```
+
+Another example (creating an issue):
+
+```json
+{
+  "tool": "redmine_request",
+  "arguments": {
+    "path": "/issues.json",
+    "method": "post",
+    "data": {
+      "issue": {
+        "project_id": 1,
+        "subject": "New task",
+        "description": "Task description"
+      }
+    },
+    "user_identifier": "jan.kowalski@company.com"
+  }
+}
+```
+
+### API Key Resolution Logic
+
+The server resolves the API key in this order:
+
+1. **`user_identifier` provided + `REDMINE_USERS_MAP` configured** → Look up key in map. If user not found → **error** (no fallback, to prevent accidental use of wrong identity).
+2. **No `user_identifier` provided** → Use global `REDMINE_API_KEY` (if configured).
+3. **Neither available** → Error.
+
+### LLM System Prompt Integration
+
+If an LLM is involved in the tool-calling chain (e.g. OpenWebUI → LLM → n8n → MCP), the LLM's system prompt should instruct it to always pass the user identifier. Example system prompt addition:
+
+```
+When calling any Redmine MCP tool (redmine_request, redmine_upload, redmine_download),
+you MUST always include the "user_identifier" parameter with the current user's email address.
+This parameter is required for authentication — without it, the request will fail.
+The user_identifier is: {{USER_EMAIL}}
+```
+
 ## Environment Variables
 
 | Variable | Required | Default | Description |
 |----------|----------|---------|-------------|
 | `REDMINE_URL` | Yes | - | URL of your Redmine instance. Subpaths are supported (e.g., `http://localhost/redmine/`) |
-| `REDMINE_API_KEY` | Yes | - | Your Redmine API key (see below for how to get it) |
+| `REDMINE_API_KEY` | Conditional | - | Your Redmine API key. Required unless `REDMINE_USERS_MAP` is configured. Used as fallback when no `user_identifier` is provided (see below for how to get it) |
+| `REDMINE_USERS_MAP` | Conditional | - | Path to a JSON file or inline JSON string mapping user identifiers to Redmine API keys. Required unless `REDMINE_API_KEY` is configured. At least one of `REDMINE_API_KEY` or `REDMINE_USERS_MAP` must be set |
 | `REDMINE_REQUEST_INSTRUCTIONS` | No | - | Path to a file containing additional instructions for the redmine_request tool. I've found it works great to have the LLM generate that file after a session. ([example1](INSTRUCTIONS_EXAMPLE1.md) [example2](INSTRUCTIONS_EXAMPLE2.md)) |
 | `REDMINE_HEADERS` | No | (empty) | Custom HTTP headers to include in all requests. Format: `"Header1: Value1, Header2: Value2"`. Useful for proxies that require additional authentication (e.g., `X-Redmine-Username`) |
 | `REDMINE_RESPONSE_FORMAT` | No | `yaml` | Response format: `yaml` or `json`. Controls how API responses are formatted |
@@ -165,6 +294,7 @@ Add to your `claude_desktop_config.json`:
     - `method` (string, optional): HTTP method to use (default: 'get')
     - `data` (object, optional): Dictionary for request body (for POST/PUT)
     - `params` (object, optional): Dictionary for query parameters
+    - `user_identifier` (string, **required in multi-user mode**): User identifier (e.g. email address) for API key resolution. The orchestrator (e.g. n8n) must provide this in every tool call.
   - Returns YAML string containing response status code, body and error message:
   ```yaml
   status_code: 200
@@ -182,6 +312,7 @@ Add to your `claude_desktop_config.json`:
   - Inputs:
     - `file_path` (string): Fully qualified path to the file to upload (must be within allowed directories)
     - `description` (string, optional): Optional description for the file
+    - `user_identifier` (string, **required in multi-user mode**): User identifier (e.g. email address) for API key resolution. The orchestrator (e.g. n8n) must provide this in every tool call.
   - Returns YAML string with the same format as redmine_request, including upload token:
   ```yaml
   status_code: 201
@@ -199,6 +330,7 @@ Add to your `claude_desktop_config.json`:
     - `attachment_id` (integer): The ID of the attachment to download
     - `save_path` (string): Fully qualified path where the file should be saved (must be within allowed directories)
     - `filename` (string, optional): Optional filename to use (determined automatically if not provided)
+    - `user_identifier` (string, **required in multi-user mode**): User identifier (e.g. email address) for API key resolution. The orchestrator (e.g. n8n) must provide this in every tool call.
   - Returns YAML string with download results:
   ```yaml
   status_code: 200

--- a/mcp_redmine/server.py
+++ b/mcp_redmine/server.py
@@ -16,8 +16,48 @@ with open(current_dir / 'redmine_openapi.yml') as f:
 
 # Constants from environment
 REDMINE_URL = os.environ['REDMINE_URL'].rstrip('/') + '/'  # Normalize to always end with /
-REDMINE_API_KEY = os.environ['REDMINE_API_KEY']
+REDMINE_API_KEY = os.environ.get('REDMINE_API_KEY', '')
 REDMINE_RESPONSE_FORMAT = os.environ.get('REDMINE_RESPONSE_FORMAT', 'yaml').lower()
+
+# Multi-user support: map of user_identifier -> Redmine API key
+# Can be a path to a JSON file or inline JSON string
+REDMINE_USERS_MAP_SOURCE = os.environ.get('REDMINE_USERS_MAP', '')
+_USERS_MAP_PATH = None  # Set if source is a file path (enables hot-reload)
+
+def _load_users_map() -> dict:
+    """Load users map from file (hot-reload) or return cached inline map."""
+    global _USERS_MAP_PATH
+    if _USERS_MAP_PATH:
+        try:
+            with open(_USERS_MAP_PATH) as f:
+                return json.load(f)
+        except Exception as e:
+            get_logger(__name__).error(f"Failed to load users map from {_USERS_MAP_PATH}: {e}")
+            return {}
+    return {}
+
+_INLINE_USERS_MAP = {}
+if REDMINE_USERS_MAP_SOURCE:
+    source = REDMINE_USERS_MAP_SOURCE.strip()
+    if source.startswith('{'):
+        # Inline JSON
+        _INLINE_USERS_MAP = json.loads(source)
+    else:
+        # File path
+        _USERS_MAP_PATH = source
+        # Validate file exists at startup
+        if not pathlib.Path(_USERS_MAP_PATH).exists():
+            raise FileNotFoundError(f"REDMINE_USERS_MAP file not found: {_USERS_MAP_PATH}")
+
+def _get_users_map() -> dict:
+    """Get the current users map (supports hot-reload for file-based maps)."""
+    if _USERS_MAP_PATH:
+        return _load_users_map()
+    return _INLINE_USERS_MAP
+
+# Validate that at least one auth method is configured
+if not REDMINE_API_KEY and not REDMINE_USERS_MAP_SOURCE:
+    raise ValueError("Either REDMINE_API_KEY or REDMINE_USERS_MAP must be configured")
 
 # Custom headers (format: "Header1: Value1, Header2: Value2")
 REDMINE_HEADERS = {}
@@ -45,10 +85,39 @@ else:
 
 
 # Core
+
+def resolve_api_key(user_identifier: str = None) -> str:
+    """Resolve Redmine API key from user_identifier or fall back to global key.
+
+    Resolution order:
+    1. If user_identifier provided and REDMINE_USERS_MAP configured -> lookup in map (error if not found)
+    2. If no user_identifier -> use global REDMINE_API_KEY
+    3. If nothing available -> raise error
+    """
+    if user_identifier:
+        users_map = _get_users_map()
+        if users_map:
+            key = users_map.get(user_identifier)
+            if key:
+                return key
+            raise ValueError(
+                f"Unknown user_identifier: '{user_identifier}'. "
+                f"User not found in REDMINE_USERS_MAP configuration."
+            )
+        # No map configured but user_identifier provided - fall through to global key
+    if REDMINE_API_KEY:
+        return REDMINE_API_KEY
+    raise ValueError(
+        "No API key available. Either provide a valid user_identifier "
+        "(mapped in REDMINE_USERS_MAP) or configure REDMINE_API_KEY."
+    )
+
+
 def request(path: str, method: str = 'get', data: dict = None, params: dict = None,
-            content_type: str = 'application/json', content: bytes = None) -> dict:
+            content_type: str = 'application/json', content: bytes = None,
+            api_key: str = None) -> dict:
     headers = {
-        'X-Redmine-API-Key': REDMINE_API_KEY,
+        'X-Redmine-API-Key': api_key or REDMINE_API_KEY,
         'Content-Type': content_type,
         **REDMINE_HEADERS
     }
@@ -82,7 +151,7 @@ def request(path: str, method: str = 'get', data: dict = None, params: dict = No
                 body = None
 
         return {"status_code": status_code, "body": body, "error": f"{e.__class__.__name__}: {e}"}
-        
+
 def format_response(obj):
     """Format response as YAML or JSON based on REDMINE_RESPONSE_FORMAT env var."""
     if REDMINE_RESPONSE_FORMAT == 'json':
@@ -129,29 +198,40 @@ mcp = FastMCP("Redmine MCP server")
 get_logger(__name__).info(f"Starting MCP Redmine version {VERSION}")
 
 @mcp.tool(description="""
-Make a request to the Redmine API
+Make a request to the Redmine API.
+
+IMPORTANT: The 'user_identifier' parameter is REQUIRED for every request in multi-user deployments.
+It must be passed via the tool call arguments. The orchestrator (e.g. n8n) MUST include the
+user's identifier (typically their email address) in every tool call so that the correct
+Redmine API key is resolved for each user.
 
 Args:
     path: API endpoint path (e.g. '/issues.json')
     method: HTTP method to use (default: 'get')
     data: Dictionary for request body (for POST/PUT)
     params: Dictionary for query parameters
+    user_identifier: User identifier (e.g. email) for multi-user API key resolution. MUST be provided by the orchestrator for every request.
 
 Returns:
     str: YAML string containing response status code, body and error message
 
 {}""".format(REDMINE_REQUEST_INSTRUCTIONS).strip())
-    
-def redmine_request(path: str, method: str = 'get', data: dict = None, params: dict = None) -> str:
-    return wrap_insecure_content(format_response(request(path, method=method, data=data, params=params)))
+
+def redmine_request(path: str, method: str = 'get', data: dict = None, params: dict = None,
+                    user_identifier: str = None) -> str:
+    try:
+        api_key = resolve_api_key(user_identifier)
+    except ValueError as e:
+        return format_response({"status_code": 0, "body": None, "error": str(e)})
+    return wrap_insecure_content(format_response(request(path, method=method, data=data, params=params, api_key=api_key)))
 
 @mcp.tool()
 def redmine_paths_list() -> str:
     """Return a list of available API paths from OpenAPI spec
-    
+
     Retrieves all endpoint paths defined in the Redmine OpenAPI specification. Remember that you can use the
     redmine_paths_info tool to get the full specfication for a path.
-    
+
     Returns:
         str: YAML string containing a list of path templates (e.g. '/issues.json')
     """
@@ -160,10 +240,10 @@ def redmine_paths_list() -> str:
 @mcp.tool()
 def redmine_paths_info(path_templates: list) -> str:
     """Get full path information for given path templates
-    
+
     Args:
         path_templates: List of path templates (e.g. ['/issues.json', '/projects.json'])
-        
+
     Returns:
         str: YAML string containing API specifications for the requested paths
     """
@@ -175,18 +255,28 @@ def redmine_paths_info(path_templates: list) -> str:
     return format_response(info)
 
 @mcp.tool()
-def redmine_upload(file_path: str, description: str = None) -> str:
+def redmine_upload(file_path: str, description: str = None, user_identifier: str = None) -> str:
     """
-    Upload a file to Redmine and get a token for attachment
+    Upload a file to Redmine and get a token for attachment.
+
+    IMPORTANT: The 'user_identifier' parameter is REQUIRED for every request in multi-user deployments.
+    The orchestrator (e.g. n8n) MUST include the user's identifier (typically their email address)
+    in every tool call so that the correct Redmine API key is resolved for each user.
 
     Args:
         file_path: Fully qualified path to the file to upload (must be within REDMINE_ALLOWED_DIRECTORIES)
         description: Optional description for the file
+        user_identifier: User identifier (e.g. email) for multi-user API key resolution. MUST be provided by the orchestrator for every request.
 
     Returns:
         str: YAML string containing response status code, body and error message
              The body contains the attachment token
     """
+    try:
+        api_key = resolve_api_key(user_identifier)
+    except ValueError as e:
+        return format_response({"status_code": 0, "body": None, "error": str(e)})
+
     error, path = validate_path(file_path, must_exist=True)
     if error:
         return format_response({"status_code": 0, "body": None, "error": error})
@@ -200,25 +290,36 @@ def redmine_upload(file_path: str, description: str = None) -> str:
             file_content = f.read()
 
         result = request(path='uploads.json', method='post', params=params,
-                         content_type='application/octet-stream', content=file_content)
+                         content_type='application/octet-stream', content=file_content, api_key=api_key)
         return format_response(result)
     except Exception as e:
         return format_response({"status_code": 0, "body": None, "error": f"{e.__class__.__name__}: {e}"})
 
 @mcp.tool()
-def redmine_download(attachment_id: int, save_path: str, filename: str = None) -> str:
+def redmine_download(attachment_id: int, save_path: str, filename: str = None,
+                     user_identifier: str = None) -> str:
     """
-    Download an attachment from Redmine and save it to a local file
+    Download an attachment from Redmine and save it to a local file.
+
+    IMPORTANT: The 'user_identifier' parameter is REQUIRED for every request in multi-user deployments.
+    The orchestrator (e.g. n8n) MUST include the user's identifier (typically their email address)
+    in every tool call so that the correct Redmine API key is resolved for each user.
 
     Args:
         attachment_id: The ID of the attachment to download
         save_path: Fully qualified path where the file should be saved to (must be within REDMINE_ALLOWED_DIRECTORIES)
         filename: Optional filename to use for the attachment. If not provided,
                  will be determined from attachment data or URL
+        user_identifier: User identifier (e.g. email) for multi-user API key resolution. MUST be provided by the orchestrator for every request.
 
     Returns:
         str: YAML string containing download status, file path, and any error messages
     """
+    try:
+        api_key = resolve_api_key(user_identifier)
+    except ValueError as e:
+        return format_response({"status_code": 0, "body": None, "error": str(e)})
+
     error, path = validate_path(save_path, must_exist=False)
     if error:
         return format_response({"status_code": 0, "body": None, "error": error})
@@ -228,14 +329,14 @@ def redmine_download(attachment_id: int, save_path: str, filename: str = None) -
 
     try:
         if not filename:
-            attachment_response = request(f"attachments/{attachment_id}.json", "get")
+            attachment_response = request(f"attachments/{attachment_id}.json", "get", api_key=api_key)
             if attachment_response["status_code"] != 200:
                 return format_response(attachment_response)
 
             filename = attachment_response["body"]["attachment"]["filename"]
 
         response = request(f"attachments/download/{attachment_id}/{filename}", "get",
-                           content_type="application/octet-stream")
+                           content_type="application/octet-stream", api_key=api_key)
         if response["status_code"] != 200 or not response["body"]:
             return format_response(response)
 


### PR DESCRIPTION
Allow a single MCP server instance to serve multiple Redmine users, each with their own API key. Users are identified by email (or other identifier) mapped to API keys via REDMINE_USERS_MAP config.

Changes:
- Add REDMINE_USERS_MAP env var (JSON file path or inline JSON)
- Add user_identifier parameter to redmine_request, redmine_upload, and redmine_download tools
- Add resolve_api_key() with strict lookup (error if user not found)
- Hot-reload support for users map file (no restart needed)
- REDMINE_API_KEY is now optional (fallback when no user_identifier)
- Full multi-user documentation in README with n8n/OpenWebUI examples
- Security warning: multi-user mode is for closed networks only