### PR TITLE
fix: use persistent httpx.Client to eliminate per-call TCP/TLS overhead

### DIFF
--- a/mcp_redmine/server.py
+++ b/mcp_redmine/server.py
@@ -40,7 +40,13 @@ REDMINE_DANGEROUSLY_ACCEPT_INVALID_CERTS = os.environ.get('REDMINE_DANGEROUSLY_A
 # Persistent HTTP client — reuses TCP/TLS connections across calls instead of opening a new one each time.
 # Using httpx.request() (top-level function) creates a new connection per call, which adds ~2 minutes of
 # TLS handshake overhead on each request when connecting to internal/corporate Redmine servers.
-_http_client = httpx.Client(timeout=60.0, verify=not REDMINE_DANGEROUSLY_ACCEPT_INVALID_CERTS)
+# keepalive_expiry=120 keeps connections alive for 2 minutes; the httpx default of 5s means every call
+# after a short pause pays a full ~600ms TLS reconnect cost.
+_http_client = httpx.Client(
+    timeout=60.0,
+    verify=not REDMINE_DANGEROUSLY_ACCEPT_INVALID_CERTS,
+    limits=httpx.Limits(max_keepalive_connections=5, keepalive_expiry=120),
+)
 
 if "REDMINE_REQUEST_INSTRUCTIONS" in os.environ:
     with open(os.environ["REDMINE_REQUEST_INSTRUCTIONS"]) as f:

--- a/mcp_redmine/server.py
+++ b/mcp_redmine/server.py
@@ -37,6 +37,11 @@ REDMINE_ALLOWED_DIRECTORIES = [
 # SSL verification (disabled only when explicitly set to "1")
 REDMINE_DANGEROUSLY_ACCEPT_INVALID_CERTS = os.environ.get('REDMINE_DANGEROUSLY_ACCEPT_INVALID_CERTS') == '1'
 
+# Persistent HTTP client — reuses TCP/TLS connections across calls instead of opening a new one each time.
+# Using httpx.request() (top-level function) creates a new connection per call, which adds ~2 minutes of
+# TLS handshake overhead on each request when connecting to internal/corporate Redmine servers.
+_http_client = httpx.Client(timeout=60.0, verify=not REDMINE_DANGEROUSLY_ACCEPT_INVALID_CERTS)
+
 if "REDMINE_REQUEST_INSTRUCTIONS" in os.environ:
     with open(os.environ["REDMINE_REQUEST_INSTRUCTIONS"]) as f:
         REDMINE_REQUEST_INSTRUCTIONS = f.read()
@@ -55,8 +60,8 @@ def request(path: str, method: str = 'get', data: dict = None, params: dict = No
     url = urljoin(REDMINE_URL, path.lstrip('/'))
 
     try:
-        response = httpx.request(method=method.lower(), url=url, json=data, params=params, headers=headers,
-                                 content=content, timeout=60.0, verify=not REDMINE_DANGEROUSLY_ACCEPT_INVALID_CERTS)
+        response = _http_client.request(method=method.lower(), url=url, json=data, params=params, headers=headers,
+                                       content=content)
         response.raise_for_status()
 
         body = None


### PR DESCRIPTION
## Problem

`httpx.request()` (the top-level convenience function) creates a **brand new TCP connection and TLS handshake on every single API call**. On internal/corporate Redmine servers this adds ~2 minutes of overhead per request, making bulk operations extremely slow.

We measured this empirically:
- Fetch 1 ticket: **~2 min 3 sec**
- Update 1 ticket: **~2 min 6 sec**
- 10 calls total (5 fetch + 5 update) = **~20 minutes** for what should take seconds

## Fix

Replace `httpx.request()` with a module-level `httpx.Client` instance that reuses the underlying TCP/TLS connection across calls. After the first connection is established, subsequent calls reuse it — reducing latency to milliseconds.

```python
# Before: new connection every call
response = httpx.request(method=..., verify=..., timeout=...)

# After: persistent client, connection reused
_http_client = httpx.Client(timeout=60.0, verify=not REDMINE_DANGEROUSLY_ACCEPT_INVALID_CERTS)
response = _http_client.request(method=...)
```

## Why this happens

`httpx.request()` is a convenience wrapper that internally does:
```python
with httpx.Client(...) as client:
    return client.request(...)
```
The `with` block closes the client (and its connection pool) after every call. The persistent client avoids this entirely.

This is consistent with the [httpx docs recommendation](https://www.python-httpx.org/advanced/clients/) — use a `Client` instance for multiple requests rather than the top-level API.

## Impact

- Fixes severe latency on corporate/internal Redmine instances (HTTPS with self-signed certs or slow DNS)
- No behaviour change for public Redmine instances (just faster)
- Zero API surface change